### PR TITLE
feat: support local dependencies

### DIFF
--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -62,7 +62,13 @@ module.exports = function(filename, serverless) {
           if (ignoreMissing(moduleName)) {
             return;
           }
-          throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);
+          try {
+            // support named dependencies, e.g. something like `import * from 'my/local/dep/bla.js';`
+            // which incorrectly is assumed to be in a package named `my`.
+            require.resolve(name);
+          } catch(e) {
+            throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);
+          }
         }
       }
     });


### PR DESCRIPTION
This change allows us to use local dependencies. They can be used when multiple source roots are defined via `NODE_PATH` for example.
Currently, the plugin incorrectly assumes that anything not starting with `./` or not resolved against the cwd is a module dependency.

references https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/14 and https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/23

Happy to add an example and tests if this change is accepted.